### PR TITLE
Remove redefinition of template parameter

### DIFF
--- a/c++/sodium/sodium.h
+++ b/c++/sodium/sodium.h
@@ -884,7 +884,7 @@ namespace sodium {
      * due to behavior's delay semantics, event occurrences for the new
      * event won't come through until the following transaction.
      */
-    template <class A, class P = def_part>
+    template <class A, class P>
     event<A, P> switch_e(const behavior<event<A, P>, P>& bea)
     {
         transaction<P> trans;


### PR DESCRIPTION
Fixes:

```
❯ CXX=/usr/bin/clang++ make                                                                                                                                            
/usr/bin/clang++  -I.. --std=c++11 -g  -c -o ../sodium/transaction.o ../sodium/transaction.cpp
In file included from ../sodium/transaction.cpp:7:
../sodium/sodium.h:887:34: error: template parameter redefines default argument
    template <class A, class P = def_part>
                                 ^
../sodium/sodium.h:33:34: note: previous default template argument defined here
    template <class A, class P = def_part>
                                 ^
1 error generated.
<builtin>: recipe for target '../sodium/transaction.o' failed
make: *** [../sodium/transaction.o] Error 1
```
