### PR TITLE
prevent keepAlive from being GC'd early.

### DIFF
--- a/haskell/src/FRP/Sodium/Plain.hs
+++ b/haskell/src/FRP/Sodium/Plain.hs
@@ -349,7 +349,10 @@ execute ev = Event gl cacheRef (dep ev)
 -- | Obtain the current value of a behavior.
 sample :: Behavior a -> Reactive a
 {-# NOINLINE sample #-}
-sample = ioReactive . unSample . sampleImpl
+sample beh = ioReactive $ do
+    let sample = sampleImpl beh
+    readIORef (sampleKeepAlive sample)  -- defeat optimizer on ghc-7.8
+    unSample sample
 
 -- | If there's more than one firing in a single transaction, combine them into
 -- one using the specified combining function.


### PR DESCRIPTION
There is a regression under GHC 7.8: when compiled with optimizations enabled (-O), some events stop being propagated. It turns out that the `sampleKeepAlive` reference on which a finalizer is attached gets garbage-collected early, so this patch explicitly reads from that reference in order to keep it alive.

Here is a small program demonstrating the problem:

```
$ cat Main.hs
module Main where

import Control.Concurrent
import FRP.Sodium

main :: IO ()
main = do
    (int, changeInt) <- sync (newBehaviour (0 :: Int))

    let loop n = do
          x <- sync $ do
                 changeInt n
                 sample int
          print x
          threadDelay 10000
          loop (n+1)
    loop 0
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.8.3
$ ghc -O Main.hs ./Main
[1 of 1] Compiling Main             ( Main.hs, Main.o )
Linking Main ...
$ ./Main
[...]
92
93
94
95
96
96
96
96
96
```
