### PR TITLE
Fixed typos

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -6,7 +6,7 @@ project(sodium)
 include(CheckCXXCompilerFlag)
 
 check_cxx_compiler_flag("-std=c++11" SUPPORTS_CXX11)
-if( SUPPORTS_CX11 )
+if( SUPPORTS_CXX11 )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 else()
     check_cxx_compiler_flag("-std=c++0x" SUPPORTS_CXX0X)

--- a/c++/README.mkd
+++ b/c++/README.mkd
@@ -1,7 +1,7 @@
 BUILDING SODIUM
 ===============
 
-To build (form c++ subdirectory):
+To build (from c++ subdirectory):
 
     mkdir build
     cd build
@@ -17,4 +17,4 @@ e.g., use
 
     cmake -G'Xcode' ..
 
-To generate and Xcode project
+To generate an Xcode project


### PR DESCRIPTION
...and now, fixed the typos in my previous pull request...sorry. Funny how I only notice when I see my previous pull request. The cmake file did work before on clang/gcc, but it would have missed compilers where ONLY -std=c++11 was supported (and not -std=c++0x).

Best,
@antmd
