### PR TITLE
fix c++ pthread.h path for linux

### DIFF
--- a/c++/sodium/transaction.h
+++ b/c++/sodium/transaction.h
@@ -18,7 +18,11 @@
 #include <set>
 #include <list>
 #include <memory>
+#ifdef __linux
+#include <pthread.h>
+#else
 #include <pthread/pthread.h>
+#endif
 #if defined(SODIUM_NO_CXX11)
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>


### PR DESCRIPTION
c++ sodium was failing on linux with this error:

sodium/c++/sodium/transaction.h:21:29: fatal error: pthread/pthread.h: No such file or directory
compilation terminated.
make[2]: **\* [CMakeFiles/libsodium.dir/sodium/transaction.cpp.o] Error 1
make[1]: **\* [CMakeFiles/libsodium.dir/all] Error 2
make: **\* [all] Error 2
