### PR TITLE
Removing cut and pasted code from StreamSink and StreamLoop

### DIFF
--- a/java/sodium/src/sodium/StreamLoop.java
+++ b/java/sodium/src/sodium/StreamLoop.java
@@ -1,8 +1,6 @@
 package sodium;
 
-import java.util.List;
-
-public class StreamLoop<A> extends Stream<A> {
+public class StreamLoop<A> extends StreamWithSend<A> {
     private Stream<A> ea_out;
 
     public StreamLoop()
@@ -16,26 +14,6 @@ public class StreamLoop<A> extends Stream<A> {
             throw new RuntimeException("StreamLoop sampled before it was looped");
         return ea_out.sampleNow();
 	}
-
-    // TO DO: Copy & paste from StreamSink. Can we improve this?
-    private void send(Transaction trans, A a) {
-        if (firings.isEmpty())
-            trans.last(new Runnable() {
-            	public void run() { firings.clear(); }
-            });
-        firings.add(a);
-
-        @SuppressWarnings("unchecked")
-		List<TransactionHandler<A>> listeners = (List<TransactionHandler<A>>)this.listeners.clone();
-    	for (TransactionHandler<A> action : listeners) {
-    		try {
-                action.run(trans, a);
-    		}
-    		catch (Throwable t) {
-    		    t.printStackTrace();
-    		}
-    	}
-    }
 
     public void loop(Stream<A> ea_out)
     {

--- a/java/sodium/src/sodium/StreamSink.java
+++ b/java/sodium/src/sodium/StreamSink.java
@@ -1,8 +1,6 @@
 package sodium;
 
-import java.util.List;
-
-public class StreamSink<A> extends Stream<A> {
+public class StreamSink<A> extends StreamWithSend<A> {
     public StreamSink() {}
 
 	public void send(final A a) {
@@ -10,23 +8,4 @@ public class StreamSink<A> extends Stream<A> {
 			public void run(Transaction trans) { send(trans, a); }
 		});
 	}
-
-    void send(Transaction trans, A a) {
-        if (firings.isEmpty())
-            trans.last(new Runnable() {
-            	public void run() { firings.clear(); }
-            });
-        firings.add(a);
-        
-        @SuppressWarnings("unchecked")
-		List<TransactionHandler<A>> listeners = (List<TransactionHandler<A>>)this.listeners.clone();
-    	for (TransactionHandler<A> action : listeners) {
-    		try {
-                action.run(trans, a);
-    		}
-    		catch (Throwable t) {
-    		    t.printStackTrace();
-    		}
-    	}
-    }
 }

--- a/java/sodium/src/sodium/StreamWithSend.java
+++ b/java/sodium/src/sodium/StreamWithSend.java
@@ -1,0 +1,28 @@
+package sodium;
+
+import java.util.List;
+
+public class StreamWithSend<A> extends Stream<A> {
+
+	protected void send(Transaction trans, A a) {
+		if (firings.isEmpty())
+			trans.last(new Runnable() {
+				public void run() {
+					firings.clear();
+				}
+			});
+		firings.add(a);
+
+		@SuppressWarnings("unchecked")
+		List<TransactionHandler<A>> listeners = (List<TransactionHandler<A>>) this.listeners
+				.clone();
+		for (TransactionHandler<A> action : listeners) {
+			try {
+				action.run(trans, a);
+			} catch (Throwable t) {
+				t.printStackTrace();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
There was a comment in the Java  code to remove some cut and pasted code - this PR fixes this issue by using a common parent class.

By the way - a quick heads up - over the weekend I have been working on [Scala version of the code](https://github.com/butlermh/sodium/tree/sodium-scala/scala).

However I am not ready to submit a PR because it is failing five tests - I will let you know when it is complete. 

Very best!