### PR TITLE
public removed from close() in Transaction.

### DIFF
--- a/java/sodium/src/sodium/Transaction.java
+++ b/java/sodium/src/sodium/Transaction.java
@@ -182,7 +182,7 @@ public final class Transaction {
 	    }
 	}
 
-	public void close() {
+	void close() {
 	    while (true) {
 	        checkRegen();
 		    if (prioritizedQ.isEmpty()) break;


### PR DESCRIPTION
Is there any reason why close() should not be package local ?