### PR TITLE
C++; fix compile issue of tests on OSX

### DIFF
--- a/c++/tests/memory/release-sink-machinery.cpp
+++ b/c++/tests/memory/release-sink-machinery.cpp
@@ -1,5 +1,6 @@
 #include <sodium/sodium.h>
 #include <unistd.h>
+#include <string>
 
 using namespace sodium;
 using namespace std;

--- a/c++/tests/memory/switch-memory.cpp
+++ b/c++/tests/memory/switch-memory.cpp
@@ -1,5 +1,6 @@
 #include <sodium/sodium.h>
 #include <unistd.h>
+#include <string>
 
 using namespace sodium;
 using namespace std;


### PR DESCRIPTION
Hi,
to have all tests compile on OSX I had to add the <string> header file.
Regards
Jiri