### PR TITLE
Add mapTo convenience method to event

### DIFF
--- a/c++/sodium/sodium.h
+++ b/c++/sodium/sodium.h
@@ -858,6 +858,14 @@ namespace sodium {
             }
 
             /*!
+             * Map a function over this event that always outputs a constant value.
+             */
+            template <class B>
+            event<B> map_to(const B& value) {
+                return map<B>([value] (const A&) { return value; });
+            }
+
+            /*!
              * Merge two streams of the same type into one, so that events on either input appear
              * on the returned stream.
              * <p>


### PR DESCRIPTION
This is a simple implementation of the `mapTo` function discussed in #80. I began to write the pre-cxx11 version, but then noticed that there are some functions (like merge right below) that don't have alternate versions. Also I noticed that v2 seems to be c++11 only. My opinion is that FRP would be pretty hard to use without lambdas, so moving to c++11 only makes some sense. That said, with a little guidance I can produce a backward compatible version if you feel it's necessary.

Do you think this makes sense for behaviors as well? I'm trying to imagine a situation where I'd want to map a behavior to a constant.