### PR TITLE
busy should be false when initiation and completion events fire simultaneously.

### DIFF
--- a/book/real-world/java/lookup/Lookup.java
+++ b/book/real-world/java/lookup/Lookup.java
@@ -18,8 +18,8 @@ class IsBusy<A,B> {
                    .orElse(sIn.map(i -> true))
                    .hold(false);
     }
-    public Stream<B> sOut;
-    public Cell<Boolean> busy;
+    public final Stream<B> sOut;
+    public final Cell<Boolean> busy;
 }
 
 public class Lookup {

--- a/book/real-world/java/lookup/Lookup.java
+++ b/book/real-world/java/lookup/Lookup.java
@@ -101,7 +101,7 @@ public class Lookup {
             IsBusy<String, Optional<String>> ib =
                                      new IsBusy<>(lookup, sWord);
             Stream<String> sDefinition = ib.sOut
-                .map(o -> o.isPresent() ? o.get() : "ERROR!");
+                .map(o -> o.orElse("ERROR!"));
             Cell<String> definition = sDefinition.hold("");
             Cell<String> output = definition.lift(ib.busy, (def, bsy) ->
                 bsy ? "Looking up..." : def);

--- a/book/real-world/java/lookup/Lookup.java
+++ b/book/real-world/java/lookup/Lookup.java
@@ -14,9 +14,9 @@ import java.util.Optional;
 class IsBusy<A,B> {
     public IsBusy(Lambda1<Stream<A>, Stream<B>> action, Stream<A> sIn) {
         sOut = action.apply(sIn);
-        busy = sIn.map(i -> true)
-                  .orElse(sOut.map(i -> false))
-                  .hold(false);
+        busy = sOut.map(i -> false)
+                   .orElse(sIn.map(i -> true))
+                   .hold(false);
     }
     public Stream<B> sOut;
     public Cell<Boolean> busy;


### PR DESCRIPTION
`lookup` is a asynchronous operation and events from `sIn` and `sOut` can't be simultaneous. So the current decision about `merge` is fine when we think about the whole Lookup application.
But when we think about `IsBusy` locally, it is better to not assume events aren't simultaneous, right? `busy` should be false in the end of transaction when events are simultaneous (i.e., drop `sIn`).