### PR TITLE
Fix inverted logic for --no-shuffle

### DIFF
--- a/book/von-neumann/linked-list.c
+++ b/book/von-neumann/linked-list.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 
 typedef struct Node {
@@ -34,7 +35,7 @@ int main(int argc, char* argv[])
             nodes[i]->value = i;
         }
         shuffle(nodes, n,
-            argc == 2 && strcmp(argv[1], "--no-shuffle") == 0);
+            !(argc == 2 && strcmp(argv[1], "--no-shuffle") == 0));
         for (i = 0; i < n; i++)
             nodes[i]->next = (i+1) < n ? nodes[i+1] : NULL;
         head = nodes[0];


### PR DESCRIPTION
This revision fixes an apparent inverted logic bug in processing of the "--no-shuffle" option.

The [text](https://freecontent.manning.com/wp-content/uploads/functional-reactive-programming-in-search-of-the-mythical-von-neumann-machine.pdf) describes the `linked-list` program timing with/without the option as:

```
time ./linked-list --no-shuffle
user 0m3.390s

time ./linked-list
user 1m19.563s
```

However we saw the behavior as inverse, e.g.:

```
$ time ./linked-list --no-shuffle

real	1m24.075s
user	1m24.054s
sys	0m0.020s

$ time ./linked-list

real	0m3.724s
user	0m3.708s
sys	0m0.017s
```

Prior to this fix, including the "--no-shuffle" option would make the program shuffle list entries, which was the opposite of the intended effect.

This revision also adds an include for the string header as needed for `strcmp` to work correctly in GCC. This was tested with GCC 7.5.0 on Ubuntu 18.04.6 LTS.